### PR TITLE
Fixing update_provider()

### DIFF
--- a/embedly/embedly.php
+++ b/embedly/embedly.php
@@ -53,16 +53,17 @@ function insert_provider($obj){
             . $wpdb->escape($obj->about) . "')";
   $results = $wpdb->query( $insert );  
 }
+
 function update_provider($obj){
   global $wpdb;
   $table_name = $wpdb->prefix . "embedly_providers";
   $update = "UPDATE " . $table_name . " ".
             "SET displayname='". $wpdb->escape($obj->displayname) . "', ".
-            "SET domain='". $wpdb->escape($obj->displayname) . "', ".
-            "SET type='". $wpdb->escape($obj->displayname) . "', ".
-            "SET favicon='". $wpdb->escape($obj->displayname) . "', ".
-            "SET regex='". $wpdb->escape(json_encode($obj->regex)) . "', ".
-            "SET about='". $wpdb->escape($obj->about) . "', ".
+            "domain='". $wpdb->escape($obj->domain) . "', ".
+            "type='". $wpdb->escape($obj->type) . "', ".
+            "favicon='". $wpdb->escape($obj->favicon) . "', ".
+            "regex='". $wpdb->escape(json_encode($obj->regex)) . "', ".
+            "about='". $wpdb->escape($obj->about) . "' ".
             "WHERE name='".$wpdb->escape($obj->name)."'";
   $results = $wpdb->query( $update );
 }


### PR DESCRIPTION
Had a conversation with Art today on a support ticket (ticket #479) regarding the WP plugin not updating the provider with new updates. Art suggested I send any changes via a pull request.

Pretty straightforward fix. `update_provider()`was just failing silently due to a few SQL syntax errors. Also, the fields were mapped to the wrong attributes, so if there hadn't been the SQL syntax issues it would have even been worse.

Anyhow, attached commit should fix it. Cheers.
