### PR TITLE
Changing admin menu privilege

### DIFF
--- a/embedly.php
+++ b/embedly.php
@@ -217,7 +217,7 @@ register_deactivation_hook(__FILE__, 'embedly_deactivate');
 **/
 function embedly_add_settings_page() {
   global $embedly_settings_page;
-  $embedly_settings_page = add_menu_page('Embedly', 'Embedly', 'activate_plugins', 'embedly', 'embedly_settings_page');
+  $embedly_settings_page = add_menu_page('Embedly', 'Embedly', 'administrator', 'embedly', 'embedly_settings_page');
 }
 add_action('admin_menu', 'embedly_add_settings_page');
 


### PR DESCRIPTION
When using multisite, the Network Admin is the only one that can activate plugins. However, you still want all site admins to be able to add the API key. By changing this privilege, this gives all site admins the Embedly admin menu option to enter that API key.