### PR TITLE
Security improvements

### DIFF
--- a/embedly.php
+++ b/embedly.php
@@ -395,6 +395,12 @@ class WP_Embedly
     **/
     function embedly_save_option($key, $value)
     {
+        // Ideally we should run this through sanitize_key
+        // But some options keys have "?" in them which sanitize_key strips out
+        // Resort to sanitize_text_field instead
+       $key = sanitize_text_field( $key );
+       $value = sanitize_text_field( $value );
+
        $this->embedly_options[$key] = $value;
        update_option('embedly_settings', $this->embedly_options);
        $this->embedly_options = get_option('embedly_settings');

--- a/embedly.php
+++ b/embedly.php
@@ -310,10 +310,10 @@ class WP_Embedly
      **/
     function add_embedly_providers()
     {
-        # if user entered valid key, override providers, else, do nothing
+        // if user entered valid key, override providers, else, do nothing
         if ($this->valid_key()) {
             // delete all current oembed providers
-            add_filter('oembed_providers', create_function('', 'return array();'));
+            add_filter('oembed_providers', '__return_empty_array');
             // add embedly provider
             $provider_uri = $this->build_uri_with_options();
             wp_oembed_add_provider('#https?://[^\s]+#i', $provider_uri, true);


### PR DESCRIPTION
Hi,

We're trying to get Embedly plugin approved for wordpress.com VIP, they're pretty tight with security. I spotted a few places that require improvements - 

First commit replaces create_function with call to `__return_empty_array`
Second commit sanitizes key and value before calling `update_option`

Cheers,
Rinat.