### PR TITLE
Always use SSL in the admin.

### DIFF
--- a/embedly.php
+++ b/embedly.php
@@ -284,10 +284,9 @@ class WP_Embedly
     {
         $screen = get_current_screen();
         if ($screen->id == $this->embedly_settings_page) {
-            $protocol = is_ssl() ? 'https' : 'http';
             wp_enqueue_style('dashicons');
             wp_enqueue_style('embedly_admin_styles', EMBEDLY_URL . '/css/embedly-admin.css');
-            wp_enqueue_style('embedly-fonts', $protocol . '://embed.ly/static/styles/fontspring-stylesheet.css');
+            wp_enqueue_style('embedly-fonts', 'https://embed.ly/static/styles/fontspring-stylesheet.css');
             wp_enqueue_script('platform', '//cdn.embedly.com/widgets/platform.js', array(), '1.0', true);
         }
         return;


### PR DESCRIPTION
If the fonts can be loaded over ssl they might as well always be loaded over ssl. It's simpler no extra checks, and has no real affect on performance. Especially as tools like lets encrypt become more widely used.