### PR TITLE
Release 4.9.3: WordPress 6.9.1 compatibility and maintenance

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,5 @@
+{
+  "core": "WordPress/WordPress#6.9.1",
+  "plugins": ["."],
+  "phpVersion": "8.2"
+}

--- a/embedly.php
+++ b/embedly.php
@@ -1,12 +1,15 @@
 <?php
 /*
 Plugin Name: Embedly
-Plugin URI: http://embed.ly/wordpress
-Description: The Embedly Plugin extends Wordpress's automatic embed feature, allowing bloggers to Embed from 500+ services and counting.
+Plugin URI: https://embed.ly/wordpress
+Description: The Embedly Plugin extends WordPress's automatic embed feature, allowing bloggers to embed from 1000+ services and counting.
 Author: Embed.ly Inc
-Version: 4.9.2
-Author URI: http://embed.ly
+Version: 4.9.3
+Author URI: https://embed.ly
 License: GPL2
+Requires at least: 5.0
+Tested up to: 6.9.1
+Requires PHP: 7.4
 
 Copyright 2015 Embedly  (email : developer@embed.ly)
 
@@ -28,7 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * Define Constants
  */
 if (!defined('EMBEDLY_URL')) {
-    define('EMBEDLY_URL', plugins_url('/embedly'));
+    define('EMBEDLY_URL', untrailingslashit(plugin_dir_url(__FILE__)));
 }
 if (!defined('EMBEDLY_BASE_URI')) {
     define('EMBEDLY_BASE_URI', 'https://api.embedly.com/2/card');
@@ -61,7 +64,6 @@ class WP_Embedly
      */
     function __construct()
     {
-        global $wpdb;
         self::$instance = $this;
 
         // init settings array
@@ -95,24 +97,13 @@ class WP_Embedly
         ));
 
 
-        /**
-         * We have to check if a user's embedly api key is valid once in a while for
-         * security. If their API key was compromised, or if their acct.
-         * was deleted. This ensures plugin functionality, and proper analytics.
-         *
-         * But we don't need to do it every time the load the page.
-         */
-        if( !wp_next_scheduled( 'embedly_revalidate_account' ) ) {
-            wp_schedule_event( time(), 'hourly', 'embedly_revalidate_account' );
-        }
-
         //Admin settings page actions
         add_action('admin_menu', array(
             $this,
             'embedly_add_settings_page'
         ));
 
-        add_action('admin_print_styles', array(
+        add_action('admin_enqueue_scripts', array(
             $this,
             'embedly_enqueue_admin'
         ));
@@ -336,18 +327,16 @@ class WP_Embedly
      **/
     function embedly_add_settings_page()
     {
-        if(current_user_can('manage_options')) {
-            $icon = 'dashicons-admin-generic';
-            if( version_compare( $GLOBALS['wp_version'], '4.1', '>' ) ) {
-               $icon = 'dashicons-align-center';
-            }
-
-            $this->embedly_settings_page = add_menu_page('Embedly', 'Embedly', 'activate_plugins', 'embedly', array(
-                    $this,
-                    'embedly_settings_page'
-                ), $icon);
+        if (current_user_can('manage_options')) {
+            $this->embedly_settings_page = add_menu_page(
+                'Embedly',
+                'Embedly',
+                'manage_options',
+                'embedly',
+                array($this, 'embedly_settings_page'),
+                'dashicons-align-center'
+            );
         }
-
     }
 
 
@@ -357,7 +346,7 @@ class WP_Embedly
     function embedly_enqueue_admin()
     {
         $screen = get_current_screen();
-        if ($screen->id == $this->embedly_settings_page) {
+        if ($screen && $screen->id === $this->embedly_settings_page) {
             wp_enqueue_style('dashicons');
             wp_enqueue_style('embedly_admin_styles', EMBEDLY_URL . '/css/embedly-admin.css');
             wp_enqueue_style('embedly-fonts', 'https://cdn.embed.ly/wordpress/static/styles/fontspring-stylesheet.css');
@@ -499,7 +488,7 @@ class WP_Embedly
    {
         if ($key) {
            $result = wp_remote_retrieve_body(wp_remote_get(
-            'http://api.embed.ly/1/feature?feature=' .
+            'https://api.embed.ly/1/feature?feature=' .
             $feature .
             '&key=' .
             $key));
@@ -693,26 +682,14 @@ class WP_Embedly
     **/
     function get_compatible_dashicon($align)
     {
-      $base = '"dashicons align-icon ';
-      // WP 4.1 has the "new" align icon, else, use old one (until 3.8)
-      if( version_compare( $GLOBALS['wp_version'], '4.1', '<' ) ) {
-        if($align == 'left') {
-          // left is being reversed  to support di-none in 4.1+
-          echo $base . 'dashicons-editor-alignleft';
-        } else if($align == 'right') {
-          echo $base . 'dashicons-editor-alignleft di-reverse';
+        $base = '"dashicons align-icon ';
+        if ($align == 'left') {
+            echo $base . 'di-none';
+        } elseif ($align == 'right') {
+            echo $base . 'di-none di-reverse';
         } else {
-          echo $base . 'dashicons-editor-aligncenter';
+            echo $base . 'di-center';
         }
-      } else {
-        if($align == 'left') {
-          echo $base . 'di-none';
-        } else if($align == 'right'){
-          echo $base . 'di-none di-reverse';
-        } else {
-          echo $base . 'di-center';
-        }
-      }
     }
 
     /**
@@ -733,22 +710,19 @@ class WP_Embedly
      **/
     function embedly_settings_page()
     {
-        global $wpdb;
-        ######## BEGIN FORM HTML #########
-        #debugging:
-        #echo $this->build_uri_with_options();
-
         ?>
+        <div class="wrap">
+          <h1 class="wp-heading-inline"><?php esc_html_e('Embedly Settings', 'embedly'); ?></h1>
+
           <div class="embedly-wrap">
             <div class="embedly-ui">
               <div class="embedly-input-wrapper">
 
-                <!-- EXISTING USER MODAL -->
                 <form id="embedly_key_form" method="POST" action="">
                   <div class="embedly-ui-header-outer-wrapper">
                     <div class="embedly-ui-header-wrapper">
                       <div class="embedly-ui-header">
-                        <a class="embedly-ui-logo" href="http://embed.ly" target="_blank"><?php
+                        <a class="embedly-ui-logo" href="https://embed.ly" target="_blank"><?php
                           esc_html_e('Embedly', 'embedly');
                           ?></a>
                       </div>
@@ -759,22 +733,8 @@ class WP_Embedly
                       <div class="embedly_key_form embedly-ui-key-form">
 
                         <div id="welcome-blurb">
-                          <?php $this->get_welcome_message();  ?>
+                          <?php $this->get_welcome_message(); ?>
                         </div>
-
-                        <!--
-                        <div class="embedly-analytics">
-                          <div class="active-viewers">
-                            <h1 class="active-count"><img src=<?php echo EMBEDLY_URL . "/img/ajax-loader.gif" ?>></h1>
-                            <p>People are <strong>actively viewing</strong> your embeds!</p>
-                            <br/>
-                            <a class="emb-button" target="_blank" <?php $this->get_onclick_analytics_button(); ?>><?php esc_html_e('Realtime Analytics', 'embedly')?></a>
-                          </div>
-						  <div class="historical-viewers">
-                            <h1 class="weekly-count"><img src=<?php echo EMBEDLY_URL . "/img/ajax-loader.gif" ?>></h1>
-                            <p>People have <strong>viewed</strong> an embed in the <strong>last week</strong>.</p>
-                          </div>
-                        </div> -->
 
                         <!-- Begin 'Advanced Options' Section -->
                         <hr>
@@ -867,7 +827,7 @@ class WP_Embedly
                             <div class="embedly-tutorial-container">
                                 <p>Using the plugin is now as easy as pasting a URL into the post editor.
                                 We then do our best to find the right embed for that URL, especially if it's one of our
-                                    <strong><a href="https://embed.ly/providers" target="_blank"><?php esc_html_e('500+ providers', 'embedly'); ?></a></strong></p>
+                                    <strong><a href="https://embed.ly/providers" target="_blank"><?php esc_html_e('1000+ providers', 'embedly'); ?></a></strong></p>
                                 <p>To learn more about how the plugin works, please visit
                                     <strong><a href="https://wordpress.org/plugins/embedly" target="_blank">
                                         <?php esc_html_e('our plugin page', 'embedly'); ?></a></strong></p>
@@ -902,11 +862,15 @@ class WP_Embedly
                   </form>
                 <div id="footer">
                   <footer class="embedly-footer">
-                    &copy; <?php echo date('Y') . __( ' All Rights Reserved ', 'embedly'); ?>
+                    &copy; <?php echo esc_html( date('Y') . __( ' All Rights Reserved ', 'embedly') ); ?>
                     <span class="dashicons dashicons-heart"></span>
                     Built in Boston
                   </footer>
-                </div> <?php
+                </div>
+            </div><!-- /.embedly-ui -->
+          </div><!-- /.embedly-wrap -->
+        </div><!-- /.wrap -->
+        <?php
     } // END settings page function
 } // END WP_Embedly class
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,31 +2,31 @@
 
 Contributors: Embedly
 Tags: embed, oembed, video, image, pdf, card
-Requires at least: 3.8
-Tested up to: 4.9.4
-Stable tag: 4.9.2
+Requires at least: 5.0
+Requires PHP: 7.4
+Tested up to: 6.9.1
+Stable tag: 4.9.3
 License: GPLv2
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-The Embedly Plugin extends Wordpress's auto-embed feature to give your blog more media types and style optons.
+The Embedly Plugin extends WordPress's auto-embed feature to give your blog more media types and style options.
 
 == Description ==
 
-Enhance the default Wordpress embedding to get previews for any article,
-including your own blog posts. You also get embeds for Gfycat, Twitch, Google
-Maps, and Embedly’s growing list of [500+ supported
-providers](http://embed.ly/providers).
+Enhance the default WordPress embedding to get previews for any article,
+including your own blog posts. You also get embeds for YouTube, Vimeo, Twitch,
+Google Maps, and Embedly’s growing list of [1000+ supported
+providers](https://embed.ly/providers).
 
 You can customize the style of the embeds, to optimize for darker WP themes,
 alignment, and width. In addition, social buttons can be added around the embeds
 to make it easier to share content from your blog posts.
 
-If you have an Embedly Cards account, you can link it to the plugin with your Embedly API key.  Not only does this remove branding from the cards, it also gives you access to analytics and viewer behaviors for most popular music and video player embeds (YouTube, Vimeo, Instagram, SoundCloud).  Find out how many people viewed your embeds for how long. To learn more about Embedly Cards please visit [our website](http://embed.ly/cards).
+If you have an Embedly Cards account, you can link it to the plugin with your Embedly API key. Not only does this remove branding from the cards, it also gives you access to analytics and viewer behaviors for most popular music and video player embeds (YouTube, Vimeo, Instagram, SoundCloud). Find out how many people viewed your embeds for how long. To learn more about Embedly Cards please visit [our website](https://embed.ly/cards).
 
-Using it is as simple as the default Wordpress embedding. Embed media by pasting its URL in a single line when writing a post
+Using it is as simple as the default WordPress embedding. Embed media by pasting its URL in a single line when writing a post.
 
-The plugin automatically displays an embed of the media in the Wordpress post
-editor (for WP 4.0+).
+The plugin automatically displays an embed of the media in the WordPress post editor.
 
 Fair Warning: This plugin generates static HTML content for your posts.  After you deactivate
 the plugin, that HTML will still remain behind in all posts where the plugin was used to create
@@ -38,7 +38,7 @@ embeds.
 
 Using the Plugin Manager
 
-1. Click Plugins in the Wordpress Dashboard sidebar.
+1. Click Plugins in the WordPress Dashboard sidebar.
 
 1. Click Add New.
 
@@ -89,9 +89,9 @@ Yes
 Where do I get a key?
 =
 
-You can obtain a key when sign up for an Embedly account. You
+You can obtain a key when you sign up for an Embedly account. You
 can also get your key anytime by going to your [Embedly
-account](http://app.embed.ly).
+account](https://app.embed.ly).
 
 =
 How do I embed "any" URL?
@@ -181,6 +181,16 @@ embeds to boost SEO.
 
 
 == Changelog ==
+
+= 4.9.3 =
+
+* Tested and confirmed compatible with WordPress 6.9.1.
+* Fixed settings page capability check (manage_options instead of activate_plugins).
+* Fixed potential fatal error when get_current_screen() returns null during AJAX requests.
+* Moved admin stylesheet enqueue from deprecated admin_print_styles to admin_enqueue_scripts.
+* Fixed API key validation call to use HTTPS.
+* Updated minimum requirements: WordPress 5.0+, PHP 7.4+.
+* Removed leftover WP 3.x compatibility code.
 
 = 4.7.0 =
 
@@ -320,6 +330,10 @@ Initial Version
 
 
 == Upgrade Notice ==
+
+= 4.9.3 =
+
+Maintenance update: fixes capability check, null-safety on admin screens, HTTPS API calls, and deprecated hook. Requires WordPress 5.0+ and PHP 7.4+.
 
 = 2.0 =
 


### PR DESCRIPTION
- Bump version to 4.9.3; tested up to WordPress 6.9.1
- Raise minimum requirements to WordPress 5.0+ and PHP 7.4+
- Fix asset URL resolution to use plugin_dir_url(__FILE__) instead of hardcoded slug, correcting broken CSS/JS on non-standard installs
- Fix settings page capability: activate_plugins -> manage_options
- Fix potential fatal error when get_current_screen() returns null
- Move admin styles from deprecated admin_print_styles to admin_enqueue_scripts
- Fix API key validation endpoint to use HTTPS
- Remove orphaned cron scheduling (action hook was never registered)
- Remove WP 3.x/4.x version compatibility dead code
- Remove unused global $wpdb references
- Wrap settings page in standard WP .wrap container with page heading
- Update provider count to 1000+; fix HTTP -> HTTPS throughout
- Add .wp-env.json for local development with wp-env